### PR TITLE
[SR-114910] Add innodb lock wait timeout to percona puppet module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,9 @@
 # [*log_slave_updates*]
 #   Controls the log slave updates (true|false), needs to be set to true for async replication
 #
+# [*innodb_lock_wait_timeout*]
+#   Controls the innoDB lock wait timeout in seconds default is 50
+#   Betbuddy suggest 600
 #
 # === Examples
 #
@@ -214,6 +217,7 @@ class percona (
   $log_slave_updates = false,
   $max_binlog_files = "0",
   $max_binlog_size = "1G",
+  $innodb_lock_wait_timeout = "50",
 ) inherits percona::params {
     class { percona::server:
         mysql_version                  => $mysql_version,
@@ -269,5 +273,6 @@ class percona (
         log_slave_updates              => $log_slave_updates,
         max_binlog_files               => $max_binlog_files,
         max_binlog_size                => $max_binlog_size,
+        innodb_lock_wait_timeout       => $innodb_lock_wait_timeout,
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -212,6 +212,8 @@ class percona (
   $log_bin_file = undef,
   $log_warnings = undef,
   $log_slave_updates = false,
+  $max_binlog_files = "0",
+  $max_binlog_size = "1G",
 ) inherits percona::params {
     class { percona::server:
         mysql_version                  => $mysql_version,
@@ -265,5 +267,7 @@ class percona (
         log_bin_file                   => $log_bin_file,
         log_warnings                   => $log_warnings,
         log_slave_updates              => $log_slave_updates,
+        max_binlog_files               => $max_binlog_files,
+        max_binlog_size                => $max_binlog_size,
     }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,6 +52,7 @@ class percona::server (
   $log_slave_updates = false,
   $max_binlog_files = "0",
   $max_binlog_size = "1G",
+  $innodb_lock_wait_timeout = "50",
 ) inherits percona::params {
 
   case $::osfamily {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,8 @@ class percona::server (
   $log_bin_file = undef,
   $log_warnings = undef,
   $log_slave_updates = false,
+  $max_binlog_files = "0",
+  $max_binlog_size = "1G",
 ) inherits percona::params {
 
   case $::osfamily {

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -75,6 +75,7 @@ log_bin = <%= @log_bin_dir %>/<%= @log_bin_file %>
 <% end %>
 max_binlog_size=<%= @max_binlog_size %>
 max_binlog_files=<%= @max_binlog_files %>
+innodb_lock_wait_timeout=<%= @innodb_lock_wait_timeout %>
 
 # Disabling symbolic-links is recommended to prevent assorted security risks;
 # to do so, uncomment this line:

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -73,6 +73,8 @@ innodb_locks_unsafe_for_binlog=<%= @innodb_locks_unsafe_for_binlog %>
 <% if @log_bin_dir %>
 log_bin = <%= @log_bin_dir %>/<%= @log_bin_file %>
 <% end %>
+max_binlog_size=<%= @max_binlog_size %>
+max_binlog_files=<%= @max_binlog_files %>
 
 # Disabling symbolic-links is recommended to prevent assorted security risks;
 # to do so, uncomment this line:


### PR DESCRIPTION
Hello.

This is to add the ability to alter the `innodb_lock_wait_timeout` to the percona puppet module.

The defaults this ships with is the percona configured default which is 50seconds.

